### PR TITLE
Add validator helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,6 +300,36 @@ const MyAwesomeForm = () => {
 };
 ```
 
+## Validation helper
+
+In case you want to use several validation functions, there is `combineValidators` helper which can help you to set several validation functions for a field. This helper works with sync and async functions (by using promise for async).
+
+```tsx
+import { useForm, combineValidators } from "react-ux-form";
+
+const validateRequired = (value: string) => {
+  if (!value) {
+    return "required";
+  }
+};
+
+const validateEmail = (email: string) => {
+  if (!/.+@.+\..{2,}/.test(email)) {
+    return "invalid email";
+  }
+};
+
+const MyAwesomeForm = () => {
+  const { Field, submitForm } = useForm({
+    email: {
+      initialValue: "",
+      // will run each validation function until an error is found
+      validate: combineValidators(validateRequired, validateEmail),
+    },
+  });
+...
+```
+
 ## 👉 More examples
 
 A full set of examples in available in the [`/example` directory](https://github.com/swan-io/react-ux-form/tree/main/example) project. Just clone the repository, install its dependencies and start it!

--- a/README.md
+++ b/README.md
@@ -325,7 +325,7 @@ const MyAwesomeForm = () => {
       initialValue: "",
       // will run each validation function until an error is returned
       validate: combineValidators(
-        isEmailRequired && validateRequired, // we can make a validation conditionnal like this
+        isEmailRequired && validateRequired, // we can make a validation conditional like this
         validateEmail,
       ),
     },

--- a/README.md
+++ b/README.md
@@ -302,7 +302,7 @@ const MyAwesomeForm = () => {
 
 ## Validation helper
 
-In case you want to use several validation functions, there is `combineValidators` helper which can help you to set several validation functions for a field. This helper works with sync and async functions (by using promise for async).
+As it's a very common case to use several validation functions per field, we also export a `combineValidators` helper function that allow you to chain sync and async validation functions: it will run them sequentially until an error is returned.
 
 ```tsx
 import { useForm, combineValidators } from "react-ux-form";
@@ -323,8 +323,11 @@ const MyAwesomeForm = () => {
   const { Field, submitForm } = useForm({
     email: {
       initialValue: "",
-      // will run each validation function until an error is found
-      validate: combineValidators(validateRequired, validateEmail),
+      // will run each validation function until an error is returned
+      validate: combineValidators(
+        isEmailRequired && validateRequired, // we can make a validation conditionnal like this
+        validateEmail,
+      ),
     },
   });
 ...

--- a/__tests__/combineValidators.ts
+++ b/__tests__/combineValidators.ts
@@ -7,8 +7,8 @@ const validateRequired = (value: string) => {
   }
 };
 
-const validateMinLength = (maxLength: number) => (value: string) => {
-  if (value.length < maxLength) {
+const validateMinLength = (minLength: number) => (value: string) => {
+  if (value.length < minLength) {
     return "too short value";
   }
 };

--- a/__tests__/combineValidators.ts
+++ b/__tests__/combineValidators.ts
@@ -1,0 +1,65 @@
+import { combineValidators } from "../src";
+import { resolveAfter } from "./utils/promises";
+
+const validateRequired = (value: string) => {
+  if (!value) {
+    return "required";
+  }
+};
+
+const validateMinLength = (maxLength: number) => (value: string) => {
+  if (value.length < maxLength) {
+    return "too short value";
+  }
+};
+
+// can be done synchronously but add a delay to simulate async validation
+const validateEmail = async (email: string) => {
+  await resolveAfter(100);
+  if (!/.+@.+\..{2,}/.test(email)) {
+    return "invalid email";
+  }
+};
+
+test("combine sync validations", () => {
+  const validate = combineValidators(validateRequired, validateMinLength(6));
+
+  const input1 = "";
+  const expected1 = "required";
+  const output1 = validate(input1);
+
+  const input2 = "hello";
+  const expected2 = "too short value";
+  const output2 = validate(input2);
+
+  const input3 = "hello world";
+  const expected3 = undefined;
+  const output3 = validate(input3);
+
+  expect(output1).toBe(expected1);
+  expect(output2).toBe(expected2);
+  expect(output3).toBe(expected3);
+});
+
+test("combine sync and async validations", async () => {
+  const validate = combineValidators(validateMinLength(6), validateEmail);
+
+  const input1 = "hello";
+  const expected1 = "too short value";
+  // no need to await because there shouldn't be any async validation
+  const output1 = validate(input1);
+
+  const input2 = "hello@swan";
+  const expected2 = "invalid email";
+  // use await because email validation make `validate` async
+  const output2 = await validate(input2);
+
+  const input3 = "hello@swan.io";
+  const expected3 = undefined;
+  // use await because email validation make `validate` async
+  const output3 = await validate(input3);
+
+  expect(output1).toBe(expected1);
+  expect(output2).toBe(expected2);
+  expect(output3).toBe(expected3);
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -107,7 +107,7 @@ export const combineValidators = <T, ErrorMessage = string>(
 
     if (isPromise(result)) {
       return result.then((error) => {
-        if (error) {
+        if (error != null) {
           return error;
         }
         if (nextFns.length > 0) {


### PR DESCRIPTION
We can need to set several validations for a field, for example make it required and check it's format (isEmail for example).

To make it easier to combine several validators I added an helper named `combineValidators`.  
It combines sync and async functions.
We can also set some functions conditional (like we did with some css-in-js libs for conditional styling) for example:
```tsx
combineValidators(
  isRequired && validateRequired,
  validateEmail,
)
```

I added tests with sync and async cases.

And in documentation, I only put a basic example, I'm not sure this is a good idea to put an example with conditional validation.