### PR TITLE
Avoid validate untouched fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,10 @@ That's precisely why every field config could declare its own `strategy`:
 | `onFirstSuccessOrFirstBlur` | On first validation success or first field blur **(default)** |
 | `onSubmit`                  | On form submit                                                |
 
-👉 Note that once the first feedback is given (the field is `valid` or should display an `error` message), the field switches to what we call _"talkative"_ state.<br>
-After that, feedback will be updated on each value change until this field or the form is reset.
+👉 Note that:
+
+- The strategies will only be activated after the field value update / the form submission.
+- Once the first feedback is given (the field is `valid` or should display an `error` message), the field switches to what we call _"talkative"_ state. After that, feedback will be updated on each value change until this field or the form is reset.
 
 ## API
 

--- a/__tests__/focusHandling.tsx
+++ b/__tests__/focusHandling.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import * as React from "react";
 import { useForm } from "../src";
 
@@ -83,20 +83,20 @@ test("the first errored field is focused after submission", async () => {
     );
   };
 
-  const { findByLabelText, findByText } = render(<Test />);
+  render(<Test />);
 
-  const firstNameInput = await findByLabelText("First name");
-  const lastNameInput = await findByLabelText("Last name");
+  const firstNameInput = await screen.findByLabelText("First name");
+  const lastNameInput = await screen.findByLabelText("Last name");
 
-  const submitButton = await findByText("Submit");
+  const submitButton = await screen.findByText("Submit");
 
   fireEvent.input(firstNameInput, { target: { value: "Nicolas" } });
   fireEvent.input(lastNameInput, { target: { value: "Ni" } });
 
   fireEvent.click(submitButton);
 
-  await findByText("firstName valid");
-  await findByText("lastName error");
+  await screen.findByText("firstName valid");
+  await screen.findByText("lastName error");
 
   expect(lastNameInput).toHaveFocus();
 });
@@ -170,12 +170,12 @@ test("focusField and focusNextField behave like expected", async () => {
     );
   };
 
-  const { findByLabelText, findByText } = render(<Test />);
+  render(<Test />);
 
-  const firstNameInput = await findByLabelText("First name");
-  const lastNameInput = await findByLabelText("Last name");
+  const firstNameInput = await screen.findByLabelText("First name");
+  const lastNameInput = await screen.findByLabelText("Last name");
 
-  const focusFirstNameButton = await findByText("Focus firstName");
+  const focusFirstNameButton = await screen.findByText("Focus firstName");
 
   fireEvent.click(focusFirstNameButton);
   expect(firstNameInput).toHaveFocus();

--- a/__tests__/formStatus.tsx
+++ b/__tests__/formStatus.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import * as React from "react";
 import { useForm } from "../src";
 import { resolveAfter } from "./utils/promises";
@@ -51,23 +51,23 @@ test("formStatus evolve though time", async () => {
     );
   };
 
-  const { findByLabelText, findByText } = render(<Test />);
+  render(<Test />);
 
-  const input = await findByLabelText("First name");
-  const resetButton = await findByText("Reset");
-  const submitButton = await findByText("Submit");
+  const input = await screen.findByLabelText("First name");
+  const resetButton = await screen.findByText("Reset");
+  const submitButton = await screen.findByText("Submit");
 
-  await findByText("formStatus: untouched");
+  await screen.findByText("formStatus: untouched");
 
   fireEvent.input(input, {
     target: { value: "Nicolas" },
   });
 
-  await findByText("formStatus: editing");
+  await screen.findByText("formStatus: editing");
   fireEvent.click(submitButton);
-  await findByText("formStatus: submitted");
+  await screen.findByText("formStatus: submitted");
   fireEvent.click(resetButton);
-  await findByText("formStatus: untouched");
+  await screen.findByText("formStatus: untouched");
 });
 
 test("formStatus evolve though time with async validation", async () => {
@@ -115,24 +115,24 @@ test("formStatus evolve though time with async validation", async () => {
     );
   };
 
-  const { findByLabelText, findByText } = render(<Test />);
+  render(<Test />);
 
-  const input = await findByLabelText("First name");
-  const resetButton = await findByText("Reset");
-  const submitButton = await findByText("Submit");
+  const input = await screen.findByLabelText("First name");
+  const resetButton = await screen.findByText("Reset");
+  const submitButton = await screen.findByText("Submit");
 
-  await findByText("formStatus: untouched");
+  await screen.findByText("formStatus: untouched");
 
   fireEvent.input(input, {
     target: { value: "Nicolas" },
   });
 
-  await findByText("formStatus: editing");
+  await screen.findByText("formStatus: editing");
   fireEvent.click(submitButton);
-  await findByText("formStatus: submitting");
-  await findByText("formStatus: submitted");
+  await screen.findByText("formStatus: submitting");
+  await screen.findByText("formStatus: submitted");
   fireEvent.click(resetButton);
-  await findByText("formStatus: untouched");
+  await screen.findByText("formStatus: untouched");
 });
 
 test("formStatus evolve though time with async submission", async () => {
@@ -183,22 +183,22 @@ test("formStatus evolve though time with async submission", async () => {
     );
   };
 
-  const { findByLabelText, findByText } = render(<Test />);
+  render(<Test />);
 
-  const input = await findByLabelText("First name");
-  const resetButton = await findByText("Reset");
-  const submitButton = await findByText("Submit");
+  const input = await screen.findByLabelText("First name");
+  const resetButton = await screen.findByText("Reset");
+  const submitButton = await screen.findByText("Submit");
 
-  await findByText("formStatus: untouched");
+  await screen.findByText("formStatus: untouched");
 
   fireEvent.input(input, {
     target: { value: "Nicolas" },
   });
 
-  await findByText("formStatus: editing");
+  await screen.findByText("formStatus: editing");
   fireEvent.click(submitButton);
-  await findByText("formStatus: submitting");
-  await findByText("formStatus: submitted");
+  await screen.findByText("formStatus: submitting");
+  await screen.findByText("formStatus: submitted");
   fireEvent.click(resetButton);
-  await findByText("formStatus: untouched");
+  await screen.findByText("formStatus: untouched");
 });

--- a/__tests__/strategies.tsx
+++ b/__tests__/strategies.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import * as React from "react";
 import { useForm } from "../src";
 
@@ -172,73 +172,73 @@ test("validation strategies give feedback at the right time", async () => {
     );
   };
 
-  const { debug, findByLabelText, findByText } = render(<Test />);
+  render(<Test />);
 
-  let input = await findByLabelText("onFirstChange");
-  const resetButton = await findByText("Reset");
-  const submitButton = await findByText("Submit");
+  let input = await screen.findByLabelText("onFirstChange");
+  const resetButton = await screen.findByText("Reset");
+  const submitButton = await screen.findByText("Submit");
 
-  await findByText("onFirstChange idle");
+  await screen.findByText("onFirstChange idle");
   fireEvent.input(input, { target: { value: "Ni" } });
-  await findByText("onFirstChange error");
+  await screen.findByText("onFirstChange error");
   fireEvent.input(input, { target: { value: "Nicolas" } });
-  await findByText("onFirstChange valid");
+  await screen.findByText("onFirstChange valid");
   fireEvent.input(input, { target: { value: "Ni" } });
-  await findByText("onFirstChange error");
+  await screen.findByText("onFirstChange error");
 
   fireEvent.click(resetButton);
-  input = await findByLabelText("onFirstSuccess");
+  input = await screen.findByLabelText("onFirstSuccess");
 
-  await findByText("onFirstSuccess idle");
+  await screen.findByText("onFirstSuccess idle");
   fireEvent.input(input, { target: { value: "Ni" } });
-  await findByText("onFirstSuccess idle");
+  await screen.findByText("onFirstSuccess idle");
   fireEvent.input(input, { target: { value: "Nicolas" } });
-  await findByText("onFirstSuccess valid");
+  await screen.findByText("onFirstSuccess valid");
   fireEvent.input(input, { target: { value: "Ni" } });
-  await findByText("onFirstSuccess error");
+  await screen.findByText("onFirstSuccess error");
 
   fireEvent.click(resetButton);
-  input = await findByLabelText("onFirstBlur");
+  input = await screen.findByLabelText("onFirstBlur");
 
-  await findByText("onFirstBlur idle");
+  await screen.findByText("onFirstBlur idle");
   fireEvent.input(input, { target: { value: "Ni" } });
-  await findByText("onFirstBlur idle");
+  await screen.findByText("onFirstBlur idle");
   fireEvent.input(input, { target: { value: "Nicolas" } });
-  await findByText("onFirstBlur idle");
+  await screen.findByText("onFirstBlur idle");
   fireEvent.blur(input);
-  await findByText("onFirstBlur valid");
+  await screen.findByText("onFirstBlur valid");
   fireEvent.input(input, { target: { value: "Ni" } });
-  await findByText("onFirstBlur error");
+  await screen.findByText("onFirstBlur error");
 
   fireEvent.click(resetButton);
-  input = await findByLabelText("onFirstSuccessOrFirstBlur");
+  input = await screen.findByLabelText("onFirstSuccessOrFirstBlur");
 
-  await findByText("onFirstSuccessOrFirstBlur idle");
+  await screen.findByText("onFirstSuccessOrFirstBlur idle");
   fireEvent.input(input, { target: { value: "Ni" } });
-  await findByText("onFirstSuccessOrFirstBlur idle");
+  await screen.findByText("onFirstSuccessOrFirstBlur idle");
   fireEvent.input(input, { target: { value: "Nicolas" } });
-  await findByText("onFirstSuccessOrFirstBlur valid");
+  await screen.findByText("onFirstSuccessOrFirstBlur valid");
   fireEvent.input(input, { target: { value: "Ni" } });
-  await findByText("onFirstSuccessOrFirstBlur error");
+  await screen.findByText("onFirstSuccessOrFirstBlur error");
 
   fireEvent.click(resetButton);
 
-  await findByText("onFirstSuccessOrFirstBlur idle");
+  await screen.findByText("onFirstSuccessOrFirstBlur idle");
   fireEvent.input(input, { target: { value: "Ni" } });
-  await findByText("onFirstSuccessOrFirstBlur idle");
+  await screen.findByText("onFirstSuccessOrFirstBlur idle");
   fireEvent.blur(input);
-  await findByText("onFirstSuccessOrFirstBlur error");
+  await screen.findByText("onFirstSuccessOrFirstBlur error");
 
   fireEvent.click(resetButton);
-  input = await findByLabelText("onSubmit");
+  input = await screen.findByLabelText("onSubmit");
 
-  await findByText("onSubmit idle");
+  await screen.findByText("onSubmit idle");
   fireEvent.input(input, { target: { value: "Ni" } });
-  await findByText("onSubmit idle");
+  await screen.findByText("onSubmit idle");
   fireEvent.input(input, { target: { value: "Nicolas" } });
-  await findByText("onSubmit idle");
+  await screen.findByText("onSubmit idle");
   fireEvent.click(submitButton);
-  await findByText("onSubmit valid");
+  await screen.findByText("onSubmit valid");
   fireEvent.input(input, { target: { value: "Ni" } });
-  await findByText("onSubmit error");
+  await screen.findByText("onSubmit error");
 });

--- a/__tests__/validation.tsx
+++ b/__tests__/validation.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import * as React from "react";
 import { useForm } from "../src";
 import { resolveAfter } from "./utils/promises";
@@ -50,20 +50,19 @@ test("input validation evolve though time", async () => {
     );
   };
 
-  const { findByLabelText, findByText } = render(<Test />);
+  render(<Test />);
 
-  const input = await findByLabelText("First name");
+  const input = await screen.findByLabelText("First name");
 
   fireEvent.focus(input);
+  fireEvent.input(input, { target: { value: "Ni" } });
   fireEvent.blur(input);
 
-  await findByText("error");
+  await screen.findByText("error");
 
-  fireEvent.input(input, {
-    target: { value: "Nicolas" },
-  });
+  fireEvent.input(input, { target: { value: "Nicolas" } });
 
-  await findByText("valid");
+  await screen.findByText("valid");
 });
 
 test("input validation evolve though time with async validation", async () => {
@@ -110,20 +109,19 @@ test("input validation evolve though time with async validation", async () => {
     );
   };
 
-  const { findByLabelText, findByText } = render(<Test />);
+  render(<Test />);
 
-  const input = await findByLabelText("First name");
+  const input = await screen.findByLabelText("First name");
 
   fireEvent.focus(input);
+  fireEvent.input(input, { target: { value: "Ni" } });
   fireEvent.blur(input);
 
-  await findByText("validating");
-  await findByText("error");
+  await screen.findByText("validating");
+  await screen.findByText("error");
 
-  fireEvent.input(input, {
-    target: { value: "Nicolas" },
-  });
+  fireEvent.input(input, { target: { value: "Nicolas" } });
 
-  await findByText("validating");
-  await findByText("valid");
+  await screen.findByText("validating");
+  await screen.findByText("valid");
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -386,7 +386,10 @@ export const useForm = <Values extends Record<string, any>, ErrorMessage = strin
       // Avoid validating an untouched / already valid field
       if (validity.type !== "unknown" && !isTalkative(name)) {
         setTalkative(name, ["onFirstBlur", "onFirstSuccessOrFirstBlur"]);
-        isMounted(name) && internalValidateField(name);
+
+        if (isMounted(name)) {
+          internalValidateField(name);
+        }
       }
     };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -381,14 +381,12 @@ export const useForm = <Values extends Record<string, any>, ErrorMessage = strin
     };
 
     const getOnBlur = (name: Name) => (): void => {
-      if (isTalkative(name)) {
-        return; // Avoid validating a field validated on each change
-      }
+      const { validity } = states.current[name];
 
-      setTalkative(name, ["onFirstBlur", "onFirstSuccessOrFirstBlur"]);
-
-      if (isMounted(name)) {
-        internalValidateField(name);
+      // Avoid validating an untouched / already valid field
+      if (validity.type !== "unknown" && !isTalkative(name)) {
+        setTalkative(name, ["onFirstBlur", "onFirstSuccessOrFirstBlur"]);
+        isMounted(name) && internalValidateField(name);
       }
     };
 


### PR DESCRIPTION
There's currently a small UX issue that bugs me. A field that was only focused will perform or not the validation on blur depending of the strategy, which kinda makes sense. But I find that the feedback happen too soon:

https://user-images.githubusercontent.com/1902323/114020090-7c5a0c00-986f-11eb-9eab-8a23fe385b29.mov

So here's my proposal: You have to update the field first or it will not perform validation (for every strategy except `onSubmit`). The alternative would be providing feedback as soon as blur based strategies for `onFirstChange` and `onFirstSuccess`, but it's a bit agressive for the user.

https://user-images.githubusercontent.com/1902323/114020528-fb4f4480-986f-11eb-8556-a921e597175b.mov

