### PR TITLE
fix(examples): Missing color on fields listener

### DIFF
--- a/website/src/forms/FieldsListenerForm.tsx
+++ b/website/src/forms/FieldsListenerForm.tsx
@@ -86,6 +86,7 @@ export const FieldsListenerForm = () => {
           <pre
             style={{
               backgroundColor: "#fafafa",
+              color: "#1A202C",
               borderRadius: 6,
               borderWidth: 1,
               fontSize: 14,


### PR DESCRIPTION
Hi !

Debug section on the Fields listener example is not readable as it's missing a color attribute 🙂 